### PR TITLE
Remove dependson

### DIFF
--- a/modules/linux-function/r-storage.tf
+++ b/modules/linux-function/r-storage.tf
@@ -47,6 +47,4 @@ resource "azurerm_role_assignment" "functionapp_storage_dataowner" {
 data "azurerm_storage_account" "storage" {
   name                = var.use_existing_storage_account ? split("/", var.storage_account_id)[8] : module.storage["enabled"].storage_account.name
   resource_group_name = var.use_existing_storage_account ? split("/", var.storage_account_id)[4] : var.resource_group_name
-
-  depends_on = [module.storage]
 }

--- a/modules/windows-function/r-storage.tf
+++ b/modules/windows-function/r-storage.tf
@@ -47,6 +47,4 @@ resource "azurerm_role_assignment" "functionapp_storage_dataowner" {
 data "azurerm_storage_account" "storage" {
   name                = var.use_existing_storage_account ? split("/", var.storage_account_id)[8] : module.storage["enabled"].storage_account.name
   resource_group_name = var.use_existing_storage_account ? split("/", var.storage_account_id)[4] : var.resource_group_name
-
-  depends_on = [module.storage]
 }


### PR DESCRIPTION
<!-- Describe your Pull Request here, as normal :) -->

## Changelog entry
```
Removes unnecessary depends_on for data source. This avoids unnecessary recreations of role assignments etc.

https://support.hashicorp.com/hc/en-us/articles/15789686740499-The-combination-of-meta-argument-depends-on-with-Data-Resources
See example 2.
```

hero 1 = module "storage"
"heroes" = data "azurerm_storage_account"
hero 2 = any role assignment