### PR TITLE
ignore changes to private_dns_zone_group

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -1,3 +1,4 @@
 locals {
   function_output = try(module.linux_function["enabled"], module.windows_function["enabled"])
 }
+

--- a/modules/linux-function/r-private-endpoints.tf
+++ b/modules/linux-function/r-private-endpoints.tf
@@ -14,7 +14,10 @@ resource "azurerm_private_endpoint" "main_pe" {
 
   lifecycle {
     # Avoid recreation of the private endpoint due to moving to central module
-    ignore_changes = [private_service_connection[0].name]
+    ignore_changes = [
+      private_service_connection[0].name,
+      private_dns_zone_group,
+    ]
   }
 }
 

--- a/modules/windows-function/r-private-endpoints.tf
+++ b/modules/windows-function/r-private-endpoints.tf
@@ -14,7 +14,10 @@ resource "azurerm_private_endpoint" "main_pe" {
 
   lifecycle {
     # Avoid recreation of the private endpoint due to moving to central module
-    ignore_changes = [private_service_connection[0].name]
+    ignore_changes = [
+      private_service_connection[0].name,
+      private_dns_zone_group,
+    ]
   }
 }
 


### PR DESCRIPTION
Terraform need to ignore changes to this value to support policy that creates dns zone groups for private endpoints

## Changelog entry
```
ignore changes to private_dns_zone_group in private endpoint resources
```